### PR TITLE
style: unify volcano plot layouts

### DIFF
--- a/template_pseudo.html
+++ b/template_pseudo.html
@@ -2510,15 +2510,23 @@ function initVolcano(){
 async function renderVolcano(){
   const ct=document.getElementById('volcanoCelltype').value;
   const res = VOLCANO_DATA[ct];      // injected via code_pseudo.txt
+  const baseLayout={
+    ...PLOTLY_THEME.layout,
+    paper_bgcolor:'#ffffff',
+    plot_bgcolor:'#ffffff',
+    margin:{l:60,r:20,t:50,b:60},
+    xaxis:{showline:true,mirror:true,ticks:'outside',tickwidth:1,tickcolor:'#000',automargin:true},
+    yaxis:{showline:true,mirror:true,ticks:'outside',tickwidth:1,tickcolor:'#000',automargin:true}
+  };
   Plotly.react('volcanoPlot', res.volcanoTraces,
-    {...PLOTLY_THEME.layout, xaxis:{title:'log2FC'}, yaxis:{title:'-log10(FDR)'}, hovermode:'closest'},
+    {...baseLayout, xaxis:{...baseLayout.xaxis, title:'log2FC'}, yaxis:{...baseLayout.yaxis, title:'-log10(FDR)'}, hovermode:'closest'},
     PLOTLY_THEME.config);
   const plot=document.getElementById('volcanoPlot');
   plot.removeAllListeners && plot.removeAllListeners('plotly_click');
   function updateBox(gene){
     const traces = res.boxData[gene] || [];
     Plotly.react('volcanoBox', traces,
-      {...PLOTLY_THEME.layout, xaxis:{title:res.groupLabel}, yaxis:{title:'log1p counts'}, title:gene},
+      {...baseLayout, xaxis:{...baseLayout.xaxis, title:res.groupLabel}, yaxis:{...baseLayout.yaxis, title:'log1p counts'}, title:gene},
       PLOTLY_THEME.config);
   }
   updateBox(res.defaultGene);


### PR DESCRIPTION
## Summary
- style volcano plot and box to match predicted annotation tab
- add consistent white backgrounds, axis lines, and margins

## Testing
- `npx --yes htmlhint template_pseudo.html` *(fails: Doctype must be declared before any non-comment content)*

------
https://chatgpt.com/codex/tasks/task_e_68c5753bf9d4832c944676ad382c5099